### PR TITLE
fix: EQP - PHP 8.4 implicit nullable and XSS escaping in templates

### DIFF
--- a/Pix/Model/Pix/Boleto.php
+++ b/Pix/Model/Pix/Boleto.php
@@ -72,8 +72,8 @@ class Boleto extends \Magento\Payment\Model\Method\AbstractMethod
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Quote\Model\QuoteFactory $quoteFactory,
         \OpenPix\Pix\Api\OpenPixManagementInterface $openPixManagement,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct(

--- a/Pix/Model/Pix/Pix.php
+++ b/Pix/Model/Pix/Pix.php
@@ -72,8 +72,8 @@ class Pix extends \Magento\Payment\Model\Method\AbstractMethod
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Quote\Model\QuoteFactory $quoteFactory,
         \OpenPix\Pix\Api\OpenPixManagementInterface $openPixManagement,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct(
@@ -95,7 +95,6 @@ class Pix extends \Magento\Payment\Model\Method\AbstractMethod
         $this->openPixManagement = $openPixManagement;
         $this->_curl = $curl;
     }
-
 
     /**
      * Determine method availability based on quote amount and config data
@@ -326,13 +325,13 @@ class Pix extends \Magento\Payment\Model\Method\AbstractMethod
 
     private function isValidAddress($address)
     {
-        return !empty($address['zipcode'])
-            && !empty($address['street'])
-            && !empty($address['number'])
-            && !empty($address['neighborhood'])
-            && !empty($address['city'])
-            && !empty($address['state'])
-            && !empty($address['country']);
+        return !empty($address['zipcode']) &&
+            !empty($address['street']) &&
+            !empty($address['number']) &&
+            !empty($address['neighborhood']) &&
+            !empty($address['city']) &&
+            !empty($address['state']) &&
+            !empty($address['country']);
     }
 
     public function getPayload($order, $correlationID)

--- a/Pix/Model/Pix/PixParcelado.php
+++ b/Pix/Model/Pix/PixParcelado.php
@@ -70,8 +70,8 @@ class PixParcelado extends \Magento\Payment\Model\Method\AbstractMethod
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Quote\Model\QuoteFactory $quoteFactory,
         \OpenPix\Pix\Api\OpenPixManagementInterface $openpixManagement,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct(
@@ -232,7 +232,11 @@ class PixParcelado extends \Magento\Payment\Model\Method\AbstractMethod
         $address = $this->getAddress($billing);
 
         $this->_helperData->debugJson('Address ', self::LOG_NAME, $address);
-        $this->_helperData->debugJson('BillingAddress ', self::LOG_NAME, $billing);
+        $this->_helperData->debugJson(
+            'BillingAddress ',
+            self::LOG_NAME,
+            $billing
+        );
 
         if (!$taxIDSafe && !$email && !$phone) {
             return null;
@@ -243,7 +247,7 @@ class PixParcelado extends \Magento\Payment\Model\Method\AbstractMethod
                 'name' => $firstname . ' ' . $lastname,
                 'email' => $email,
                 'phone' => $this->formatPhone($phone),
-                'address' => $address
+                'address' => $address,
             ];
         }
 
@@ -252,7 +256,7 @@ class PixParcelado extends \Magento\Payment\Model\Method\AbstractMethod
             'taxID' => $taxIDSafe,
             'email' => $email,
             'phone' => $this->formatPhone($phone),
-            'address' => $address
+            'address' => $address,
         ];
     }
 
@@ -287,7 +291,7 @@ class PixParcelado extends \Magento\Payment\Model\Method\AbstractMethod
                 'name' => $firstname . ' ' . $lastname,
                 'email' => $email,
                 'phone' => $this->formatPhone($phone),
-                'address' => $address
+                'address' => $address,
             ];
         }
 
@@ -296,7 +300,7 @@ class PixParcelado extends \Magento\Payment\Model\Method\AbstractMethod
             'taxID' => $taxIDSafe,
             'email' => $email,
             'phone' => $this->formatPhone($phone),
-            'address' => $address
+            'address' => $address,
         ];
     }
 
@@ -316,7 +320,9 @@ class PixParcelado extends \Magento\Payment\Model\Method\AbstractMethod
             $giftBackAppliedValue = $quote->getOpenPixDiscount();
         }
 
-        $giftbackValueToApply = $this->get_amount_openpix($giftBackAppliedValue);
+        $giftbackValueToApply = $this->get_amount_openpix(
+            $giftBackAppliedValue
+        );
         $value = $this->get_amount_openpix($grandTotal) + $giftbackValueToApply;
 
         $additionalInfo = [
@@ -420,7 +426,9 @@ class PixParcelado extends \Magento\Payment\Model\Method\AbstractMethod
             $payment->setSkipOrderProcessing(true);
             $this->openpixManagement->clearDataInCache();
         } catch (\Exception $e) {
-            $this->messageManager->addErrorMessage(__('Error creating Pix Parcelado'));
+            $this->messageManager->addErrorMessage(
+                __('Error creating Pix Parcelado')
+            );
             $this->_helperData->log(
                 'Pix::Error Parcelado - Error while creating charge',
                 self::LOG_NAME,
@@ -532,7 +540,9 @@ class PixParcelado extends \Magento\Payment\Model\Method\AbstractMethod
 
             return $responseBody;
         } catch (\Exception $e) {
-            $this->messageManager->addErrorMessage(__('Error creating Pix Parcelado'));
+            $this->messageManager->addErrorMessage(
+                __('Error creating Pix Parcelado')
+            );
             $this->messageManager->addErrorMessage($e->getMessage());
             throw new \Magento\Framework\Exception\LocalizedException(
                 __($e->getMessage())

--- a/Pix/view/adminhtml/templates/info/pix.phtml
+++ b/Pix/view/adminhtml/templates/info/pix.phtml
@@ -8,6 +8,6 @@
 <dl class="payment-method purchase order">
     <dt class="title"><?= $block->escapeHtml($block->getMethod()->getTitle()) ?></dt>
     <dd class="content">
-        <img src="<?= $block->getInfo()->getOrder()->getOpenpixQrcodeimage() ?>" height="128" />
+        <img src="<?= $block->escapeUrl($block->getInfo()->getOrder()->getOpenpixQrcodeimage()) ?>" height="128" />
     </dd>
 </dl>

--- a/Pix/view/adminhtml/templates/system/config/OneclickButton.phtml
+++ b/Pix/view/adminhtml/templates/system/config/OneclickButton.phtml
@@ -11,7 +11,7 @@
         $(`${prefix}_openpix_configurations_openpix_credentials_webhook_status`)?.setAttribute('readonly','true')
 
         jQuery('#openpix_oneclick_button').click(function () {
-            new Ajax.Request('<?php echo $block->getAjaxUrl(); ?>', {
+            new Ajax.Request('<?php echo $block->escapeUrl($block->getAjaxUrl()); ?>', {
                 loaderArea: false,
                 asynchronous: true,
                 onComplete: function(transport) {

--- a/Pix/view/frontend/templates/checkout/success.phtml
+++ b/Pix/view/frontend/templates/checkout/success.phtml
@@ -17,7 +17,7 @@ $appID = $block->getAppID();
 ?>
 <?php if ($payment->getMethod() === 'openpix_pix') : ?>
     <div class="actions-toolbar flex">
-        <div id="openpix-order" data-appid="<?= $appID ?>" data-correlationID="<?= $correlationID ?>"></div>
+        <div id="openpix-order" data-appid="<?= $block->escapeHtmlAttr($appID) ?>" data-correlationID="<?= $block->escapeHtmlAttr($correlationID) ?>"></div>
 
         <script>
             require(["jquery", "OpenPix"], function($, pym) {});
@@ -25,7 +25,7 @@ $appID = $block->getAppID();
     </div>
 <?php elseif ($payment->getMethod() === 'openpix_pix_parcelado') : ?>
     <div class="actions-toolbar flex">
-        <div id="openpix-order" data-appid="<?= $appID ?>" data-correlationID="<?= $correlationID ?>"></div>
+        <div id="openpix-order" data-appid="<?= $block->escapeHtmlAttr($appID) ?>" data-correlationID="<?= $block->escapeHtmlAttr($correlationID) ?>"></div>
 
         <script>
             require(["jquery", "OpenPix"], function($, pym) {});

--- a/Pix/view/frontend/templates/info/boleto.phtml
+++ b/Pix/view/frontend/templates/info/boleto.phtml
@@ -12,27 +12,27 @@ $order = $block->getInfo()->getOrder();
     <dd class="content">
         <?php if ($order): ?>
             <div class="boleto-payment-info">
-                <h3><?= __('Boleto Bancário') ?></h3>
+                <h3><?= $block->escapeHtml(__('Boleto Bancário')) ?></h3>
                 
                 <?php if ($block->getBoletoImageUrl()): ?>
                     <div class="boleto-barcode-image">
-                        <img src="<?= $block->escapeUrl($block->getBoletoImageUrl()) ?>" alt="<?= __('Boleto Barcode') ?>" />
+                        <img src="<?= $block->escapeUrl($block->getBoletoImageUrl()) ?>" alt="<?= $block->escapeHtmlAttr(__('Boleto Barcode')) ?>" />
                     </div>
                 <?php endif; ?>
                 
                 <?php if ($block->getBoletoDigitable()): ?>
                     <div class="boleto-digitable-line">
-                        <strong><?= __('Digitable Line:') ?></strong>
+                        <strong><?= $block->escapeHtml(__('Digitable Line:')) ?></strong>
                         <p class="boleto-code"><?= $block->escapeHtml($block->getBoletoDigitable()) ?></p>
                         <button type="button" class="action copy-boleto" onclick="navigator.clipboard.writeText('<?= $block->escapeJs($block->getBoletoDigitable()) ?>')">
-                            <?= __('Copy Code') ?>
+                            <?= $block->escapeHtml(__('Copy Code')) ?>
                         </button>
                     </div>
                 <?php endif; ?>
                 
                 <?php if ($block->getBoletoBarcode()): ?>
                     <div class="boleto-barcode">
-                        <strong><?= __('Barcode:') ?></strong>
+                        <strong><?= $block->escapeHtml(__('Barcode:')) ?></strong>
                         <p class="boleto-code"><?= $block->escapeHtml($block->getBoletoBarcode()) ?></p>
                     </div>
                 <?php endif; ?>
@@ -40,14 +40,14 @@ $order = $block->getInfo()->getOrder();
                 <?php if ($block->getPaymentLinkUrl()): ?>
                     <div class="boleto-payment-link">
                         <a href="<?= $block->escapeUrl($block->getPaymentLinkUrl()) ?>" target="_blank" class="action primary">
-                            <?= __('View Boleto') ?>
+                            <?= $block->escapeHtml(__('View Boleto')) ?>
                         </a>
                     </div>
                 <?php endif; ?>
                 
                 <div class="boleto-instructions">
-                    <p><?= __('You can pay this boleto at any bank, lottery, or using your internet banking.') ?></p>
-                    <p><?= __('The payment may take up to 2 business days to be processed.') ?></p>
+                    <p><?= $block->escapeHtml(__('You can pay this boleto at any bank, lottery, or using your internet banking.')) ?></p>
+                    <p><?= $block->escapeHtml(__('The payment may take up to 2 business days to be processed.')) ?></p>
                 </div>
             </div>
         <?php endif; ?>

--- a/Pix/view/frontend/templates/info/pix.phtml
+++ b/Pix/view/frontend/templates/info/pix.phtml
@@ -11,7 +11,7 @@ $order = $block->getInfo()->getOrder();
     <dt class="title"><?= $block->escapeHtml($block->getMethod()->getTitle()) ?></dt>
     <dd class="content">
         <?php if ($order): ?>
-            <img src="<?= $order->getOpenpixQrcodeimage() ?>" width="200" height="200" />
+            <img src="<?= $block->escapeUrl($order->getOpenpixQrcodeimage()) ?>" width="200" height="200" />
         <?php endif; ?>
     </dd>
 </dl>

--- a/Pix/view/frontend/templates/multishipping/checkout/success.phtml
+++ b/Pix/view/frontend/templates/multishipping/checkout/success.phtml
@@ -15,7 +15,7 @@ $appID = $block->getAppID();
 
 <?php foreach ($qrCodes as $qrCode): ?>
     <div class="actions-toolbar flex">
-        <div id="openpix-order" data-appid="<?= $appID ?>" data-correlationID="<?= $qrCode['correlationID'] ?>"></div>
+        <div id="openpix-order" data-appid="<?= $block->escapeHtmlAttr($appID) ?>" data-correlationID="<?= $block->escapeHtmlAttr($qrCode['correlationID']) ?>"></div>
 
         <script>
             require(["jquery", "OpenPix"], function($, pym) {});

--- a/Pix/view/frontend/templates/order/payment/info.phtml
+++ b/Pix/view/frontend/templates/order/payment/info.phtml
@@ -6,7 +6,7 @@ $appID = $block->getAppID();
 
 if ($block->getPaymentMethod() === 'openpix_pix') : ?>
     <button type="button" class="action primary btn-openpix-pix" data-trigger="trigger">
-        <span data-bind="i18n: '<?= $paymentInfo['text'] ?>'"></span>
+        <span data-bind="i18n: '<?= $block->escapeHtmlAttr($paymentInfo['text']) ?>'"></span>
     </button>
     <div data-bind="mageInit: {
         'Magento_Ui/js/modal/modal':{
@@ -16,14 +16,14 @@ if ($block->getPaymentMethod() === 'openpix_pix') : ?>
             'trigger': '[data-trigger=trigger]',
             'responsive': true,
         }}">
-        <div id="openpix-order" data-appid="<?= $appID ?>" data-correlationID="<?= $correlationID ?>"></div>
+        <div id="openpix-order" data-appid="<?= $block->escapeHtmlAttr($appID) ?>" data-correlationID="<?= $block->escapeHtmlAttr($correlationID) ?>"></div>
         <script>
             require(["jquery", "OpenPix"], function($, pym) {});
         </script>
     </div>
 <?php elseif ($block->getPaymentMethod() === 'openpix_pix_parcelado') : ?>
     <button type="button" class="action primary btn-openpix-pix-parcelado" data-trigger="trigger-parcelado">
-        <span data-bind="i18n: '<?= $paymentInfo['text'] ?>'"></span>
+        <span data-bind="i18n: '<?= $block->escapeHtmlAttr($paymentInfo['text']) ?>'"></span>
     </button>
     <div data-bind="mageInit: {
         'Magento_Ui/js/modal/modal':{
@@ -33,7 +33,7 @@ if ($block->getPaymentMethod() === 'openpix_pix') : ?>
             'trigger': '[data-trigger=trigger-parcelado]',
             'responsive': true,
         }}">
-        <div id="openpix-order" data-appid="<?= $appID ?>" data-correlationID="<?= $correlationID ?>"></div>
+        <div id="openpix-order" data-appid="<?= $block->escapeHtmlAttr($appID) ?>" data-correlationID="<?= $block->escapeHtmlAttr($correlationID) ?>"></div>
         <script>
             require(["jquery", "OpenPix"], function($, pym) {});
         </script>


### PR DESCRIPTION
issue: https://github.com/entria/woovi-issues/issues/776
## Summary

- Fix PHP 8.4 implicit nullable deprecation in `Boleto`, `Pix`, and `PixParcelado` constructors — was crashing `setup:di:compile` on PHP 8.4 during EQP varnish/MFTF tests
- Fix 23 `Magento2.Security.XssTemplate.FoundUnescaped` PHPCS errors across 7 `.phtml` templates — was causing EQP PHPCS FAIL

## Files changed

**PHP 8.4 nullable fix** (`?AbstractResource` / `?AbstractDb`):
- `Pix/Model/Pix/Boleto.php`
- `Pix/Model/Pix/Pix.php`
- `Pix/Model/Pix/PixParcelado.php`

**XSS escaping fix** (`$block->escapeHtml/escapeHtmlAttr/escapeUrl/escapeJs`):
- `Pix/view/frontend/templates/info/boleto.phtml`
- `Pix/view/frontend/templates/order/payment/info.phtml`
- `Pix/view/frontend/templates/checkout/success.phtml`
- `Pix/view/frontend/templates/multishipping/checkout/success.phtml`
- `Pix/view/adminhtml/templates/info/pix.phtml`
- `Pix/view/adminhtml/templates/system/config/OneclickButton.phtml`
- `Pix/view/frontend/templates/info/pix.phtml`

## No behavior changes

The nullable fix is purely a type declaration correction. The escape methods only encode special HTML characters — all actual data (appID, correlationID, URLs, boleto digitable line) renders identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)