### PR TITLE
fix: PHP 8.4 implicit nullable in isAvailable() method

### DIFF
--- a/Pix/Model/Pix/Boleto.php
+++ b/Pix/Model/Pix/Boleto.php
@@ -104,7 +104,7 @@ class Boleto extends \Magento\Payment\Model\Method\AbstractMethod
      * @return bool
      */
     public function isAvailable(
-        \Magento\Quote\Api\Data\CartInterface $quote = null
+        ?\Magento\Quote\Api\Data\CartInterface $quote = null
     ) {
         if (!$this->_helperData->getBoletoEnabled()) {
             return false;

--- a/Pix/Model/Pix/Pix.php
+++ b/Pix/Model/Pix/Pix.php
@@ -104,7 +104,7 @@ class Pix extends \Magento\Payment\Model\Method\AbstractMethod
      * @return bool
      */
     public function isAvailable(
-        \Magento\Quote\Api\Data\CartInterface $quote = null
+        ?\Magento\Quote\Api\Data\CartInterface $quote = null
     ) {
         if (!$this->_helperData->getOpenPixEnabled()) {
             return false;

--- a/Pix/Model/Pix/PixParcelado.php
+++ b/Pix/Model/Pix/PixParcelado.php
@@ -102,7 +102,7 @@ class PixParcelado extends \Magento\Payment\Model\Method\AbstractMethod
      * @return bool
      */
     public function isAvailable(
-        \Magento\Quote\Api\Data\CartInterface $quote = null
+        ?\Magento\Quote\Api\Data\CartInterface $quote = null
     ) {
         if (!$this->_helperData->getOpenPixEnabled()) {
             return false;


### PR DESCRIPTION
issue: https://github.com/entria/woovi-issues/issues/776
## Summary

- Add explicit `?` prefix to `\Magento\Quote\Api\Data\CartInterface $quote = null` in `isAvailable()` across `Boleto`, `Pix`, and `PixParcelado`
- PHP 8.4 treats implicit nullable parameters as a fatal deprecation that aborts `setup:di:compile`
- This was the root cause of the EQP Installation & Varnish / MFTF test failures for v3.0.2

## Test plan

- [ ] Run `pnpm release:patch` to cut v3.0.3 and generate the zip
- [ ] Resubmit zip to Adobe Commerce Marketplace EQP

🤖 Generated with [Claude Code](https://claude.com/claude-code)